### PR TITLE
Fix SC on Organelle M

### DIFF
--- a/MainMenu.cpp
+++ b/MainMenu.cpp
@@ -320,7 +320,7 @@ void MainMenu::runPatch(const char* name, const char* arg) {
             }
 
             std::string args = opts;
-            sprintf(buf, "( cd /tmp/patch ; echo "" | /usr/local/bin/sclang %s \"%s\" & echo $! > /tmp/pids/sclang.pid )",
+            sprintf(buf, "( cd /tmp/patch ; echo "" | /usr/bin/sclang %s \"%s\" & echo $! > /tmp/pids/sclang.pid )",
                     args.c_str(),
                     mother.c_str()
                    );


### PR DESCRIPTION
Hi folks- 

I noticed that I couldn't launch sc patches on my organellem with the default firmware (Version: 4.2). Symptom was a black screen and no sound upon launching the sample patch from TheTechnobear ([SimplePoly.sc](https://patchstorage.com/simple-poly-on-supercollider/)). 

Currently MainMenu.cpp is looking for sclang in **/usr/local/bin** but sclang is preinstalled in **/usr/bin**.

On my own device I fixed this with a symlink, running this as root:
`# ln -s /usr/bin/sclang /usr/local/bin/sclang`
![Screenshot 2023-08-07 at 4 32 04 PM](https://github.com/critterandguitari/Organelle_OS/assets/9758721/3f2cd99f-45fd-448b-8f7c-ba390a9d6846)

DISCLAIMER: I did not recompile Organelle_OS and test this change as I do not have a build env set up for that but given the simplicity of the change I wanted to bring it to your attention.

I also originally thought I had issues with jackd... I installed that with apt-get and then apt-get remove-d it after creating the symlink and it seems like things still work and the main issue is the sclang path.

Thank you for all you do! I absolutely love this device.

Cheers,
Dune

